### PR TITLE
Fix Prepacitation Probability warning

### DIFF
--- a/custom_components/ims/sensor.py
+++ b/custom_components/ims/sensor.py
@@ -219,7 +219,6 @@ SENSOR_DESCRIPTIONS = (
         name="IMS Precipitation Probability",
         icon="mdi:cloud-percent",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.PRECIPITATION,
         state_class=SensorStateClass.MEASUREMENT,
         forecast_mode=forecast_mode.CURRENT,
         field_name=FIELD_NAME_RAIN_CHANCE,


### PR DESCRIPTION
Fixes 
```
[homeassistant.components.sensor] Entity sensor.ims_precipitation_probability (<class 'custom_components.ims.sensor.ImsSensor'>) is using native unit of measurement '%' which is not a valid unit for the device class ('precipitation') it is using; expected one of ['in', 'cm', 'mm']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/t0mer/ims-custom-component/issues
```