### PR TITLE
fix: Fix ForecastTime sensor icon

### DIFF
--- a/custom_components/ims/sensor.py
+++ b/custom_components/ims/sensor.py
@@ -217,7 +217,7 @@ SENSOR_DESCRIPTIONS: list[ImsSensorEntityDescription] = [
     ImsSensorEntityDescription(
         key=IMS_SENSOR_KEY_PREFIX + TYPE_FORECAST_TIME,
         name="IMS Forecast Time",
-        icon="mdi:weather-windy",
+        icon="mdi:calendar-clock",
         device_class=SensorDeviceClass.TIMESTAMP,
         forecast_mode=FORECAST_MODE.CURRENT,
         field_name=FIELD_NAME_FORECAST_TIME,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect icon for IMS Forecast Time sensor


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ForecastTime sensor"] -- "icon change" --> B["mdi:weather-windy"] -- "fix to" --> C["mdi:calendar-clock"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sensor.py</strong><dd><code>Update forecast time sensor icon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/ims/sensor.py

<ul><li>Changed icon for IMS Forecast Time sensor from <code>mdi:weather-windy</code> to <br><code>mdi:calendar-clock</code></ul>


</details>


  </td>
  <td><a href="https://github.com/GuyKh/ims-custom-component/pull/146/files#diff-712fb8f13857bb3c77c1914917805cc9fdd4ff0df6b9ea672ff8ec724e1f872c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

