### PR TITLE
Fix top review findings: config flow, unload lifecycle, and weather fallbacks

### DIFF
--- a/custom_components/ims/translations/en.json
+++ b/custom_components/ims/translations/en.json
@@ -4,7 +4,9 @@
             "already_configured": "Location is already configured"
         },
         "error": {
-            "cannot_connect": "Failed to connect"
+            "cannot_connect": "Failed to connect",
+            "at_least_one_platform": "Select at least one platform",
+            "invalid_city": "Selected city is no longer available"
         },
         "step": {
             "user": {

--- a/custom_components/ims/translations/he.json
+++ b/custom_components/ims/translations/he.json
@@ -4,7 +4,9 @@
             "already_configured": "מוגדר חיישן עבור ישוב זה"
         },
         "error": {
-            "cannot_connect": "שגיאה בהתחברות"
+            "cannot_connect": "שגיאה בהתחברות",
+            "at_least_one_platform": "יש לבחור לפחות סוג ישות אחד",
+            "invalid_city": "היישוב שנבחר אינו זמין יותר"
         },
         "step": {
             "user": {

--- a/custom_components/ims/translations/pt.json
+++ b/custom_components/ims/translations/pt.json
@@ -4,7 +4,9 @@
             "already_configured": "Localização já está configurada"
         },
         "error": {
-            "cannot_connect": "Falha ao conectar"
+            "cannot_connect": "Falha ao conectar",
+            "at_least_one_platform": "Selecione pelo menos uma plataforma",
+            "invalid_city": "A cidade selecionada já não está disponível"
         },
         "step": {
             "user": {

--- a/custom_components/ims/weather.py
+++ b/custom_components/ims/weather.py
@@ -240,9 +240,11 @@ class IMSWeather(WeatherEntity):
 
         condition = WEATHER_CODE_TO_CONDITION.get(str(weather_code))
         if not condition or condition == "Nothing":
-            condition = WEATHER_CODE_TO_CONDITION.get(
-                str(self._weather_coordinator.data.forecast.days[0].weather_code)
-            )
+            forecast_days = self._weather_coordinator.data.forecast.days
+            if forecast_days:
+                condition = WEATHER_CODE_TO_CONDITION.get(
+                    str(forecast_days[0].weather_code)
+                )
         return condition
 
     @property
@@ -250,7 +252,9 @@ class IMSWeather(WeatherEntity):
         """Return the weather description."""
         description = self._weather_coordinator.data.current_weather.description
         if not description or description == "Nothing":
-            description = self._weather_coordinator.data.forecast.days[0].weather
+            forecast_days = self._weather_coordinator.data.forecast.days
+            if forecast_days:
+                description = forecast_days[0].weather
         return description
 
     def _forecast(self, hourly: bool) -> list[Forecast]:


### PR DESCRIPTION
## Summary
- Fix options flow bug where cities cache stored a coroutine (missing await)
- Fix HTTP error handler signature and logging path
- Replace invalid timedelta.total_minutes() usage with total_seconds()/60
- Normalize city config handling to store city id consistently in config/options
- Prevent duplicate debug service registrations and remove the service when last entry unloads
- Return real unload status from async_unload_entry
- Add robust platform-selection fallback and validate that at least one platform is selected
- Fix _get_config_value falsey handling (None checks instead of truthiness)
- Guard weather fallback code when forecast list is empty
- Treat non-2xx API responses as connection errors during config flow
- Add translation strings for new config errors in en, he, and pt

## Validation
- ruff check custom_components/ims/__init__.py custom_components/ims/config_flow.py custom_components/ims/weather.py
- python -m compileall custom_components/ims
