### PR TITLE
Route weatheril logs through Home Assistant logging (fixes #137)

### DIFF
--- a/custom_components/ims/__init__.py
+++ b/custom_components/ims/__init__.py
@@ -31,6 +31,7 @@ from .const import (
     FORECAST_MODE_HOURLY,
 )
 
+from .dependency_logging import remove_dependency_logging, setup_dependency_logging
 from .weather_update_coordinator import WeatherUpdateCoordinator
 
 CONF_FORECAST = "forecast"
@@ -62,63 +63,70 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unique_location = f"ims-{language}-{city_id}"
 
     hass.data.setdefault(DOMAIN, {})
-    # If coordinator already exists for this API key, we'll use that, otherwise
-    # we have to create a new one
-    if unique_location in hass.data[DOMAIN]:
-        weather_coordinator = hass.data[DOMAIN].get(unique_location)
-        _LOGGER.info(
-            "An existing IMS weather coordinator already exists for this location. Using that one instead"
+
+    try:
+        setup_dependency_logging(entry.entry_id)
+
+        # If coordinator already exists for this API key, we'll use that, otherwise
+        # we have to create a new one
+        if unique_location in hass.data[DOMAIN]:
+            weather_coordinator = hass.data[DOMAIN].get(unique_location)
+            _LOGGER.info(
+                "An existing IMS weather coordinator already exists for this location. Using that one instead"
+            )
+        else:
+            weather_coordinator = WeatherUpdateCoordinator(
+                city_id, language, timedelta(minutes=ims_scan_int), hass
+            )
+            hass.data[DOMAIN][unique_location] = weather_coordinator
+            # _LOGGER.warning('New Coordinator')
+
+        # await weather_coordinator.async_refresh()
+        await weather_coordinator.async_config_entry_first_refresh()
+
+        hass.data[DOMAIN][entry.entry_id] = {
+            ENTRY_NAME: name,
+            ENTRY_WEATHER_COORDINATOR: weather_coordinator,
+            CONF_CITY: city,
+            CONF_LANGUAGE: language,
+            CONF_MODE: forecast_mode,
+            CONF_IMAGES_PATH: images_path,
+            CONF_UPDATE_INTERVAL: ims_scan_int,
+            IMS_PLATFORM: ims_entity_platform,
+            CONF_MONITORED_CONDITIONS: conditions,
+        }
+
+        # If both platforms
+        if (IMS_PLATFORMS[0] in ims_entity_platform) and (
+            IMS_PLATFORMS[1] in ims_entity_platform
+        ):
+            platforms = PLATFORMS
+        # If only sensor
+        elif IMS_PLATFORMS[0] in ims_entity_platform:
+            platforms = [PLATFORMS[0], PLATFORMS[2]]
+        # If only weather
+        elif IMS_PLATFORMS[1] in ims_entity_platform:
+            platforms = [PLATFORMS[1]]
+
+        await hass.config_entries.async_forward_entry_setups(entry, platforms)
+
+        update_listener = entry.add_update_listener(async_update_options)
+        hass.data[DOMAIN][entry.entry_id][UPDATE_LISTENER] = update_listener
+
+        # Register the debug service
+        async def handle_debug_get_coordinator_data(call) -> None:  # noqa: ANN001 ARG001
+            # Log or return coordinator data
+            data = weather_coordinator.data
+            _LOGGER.info("Coordinator data: %s", data)
+            hass.bus.async_fire("custom_component_debug_event", {"data": data})
+
+        hass.services.async_register(
+            DOMAIN, "debug_get_coordinator_data", handle_debug_get_coordinator_data
         )
-    else:
-        weather_coordinator = WeatherUpdateCoordinator(
-            city_id, language, timedelta(minutes=ims_scan_int), hass
-        )
-        hass.data[DOMAIN][unique_location] = weather_coordinator
-        # _LOGGER.warning('New Coordinator')
-
-    # await weather_coordinator.async_refresh()
-    await weather_coordinator.async_config_entry_first_refresh()
-
-    hass.data[DOMAIN][entry.entry_id] = {
-        ENTRY_NAME: name,
-        ENTRY_WEATHER_COORDINATOR: weather_coordinator,
-        CONF_CITY: city,
-        CONF_LANGUAGE: language,
-        CONF_MODE: forecast_mode,
-        CONF_IMAGES_PATH: images_path,
-        CONF_UPDATE_INTERVAL: ims_scan_int,
-        IMS_PLATFORM: ims_entity_platform,
-        CONF_MONITORED_CONDITIONS: conditions,
-    }
-
-    # If both platforms
-    if (IMS_PLATFORMS[0] in ims_entity_platform) and (
-        IMS_PLATFORMS[1] in ims_entity_platform
-    ):
-        platforms = PLATFORMS
-    # If only sensor
-    elif IMS_PLATFORMS[0] in ims_entity_platform:
-        platforms = [PLATFORMS[0], PLATFORMS[2]]
-    # If only weather
-    elif IMS_PLATFORMS[1] in ims_entity_platform:
-        platforms = [PLATFORMS[1]]
-
-    await hass.config_entries.async_forward_entry_setups(entry, platforms)
-
-    update_listener = entry.add_update_listener(async_update_options)
-    hass.data[DOMAIN][entry.entry_id][UPDATE_LISTENER] = update_listener
-
-    # Register the debug service
-    async def handle_debug_get_coordinator_data(call) -> None:  # noqa: ANN001 ARG001
-        # Log or return coordinator data
-        data = weather_coordinator.data
-        _LOGGER.info("Coordinator data: %s", data)
-        hass.bus.async_fire("custom_component_debug_event", {"data": data})
-
-    hass.services.async_register(
-        DOMAIN, "debug_get_coordinator_data", handle_debug_get_coordinator_data
-    )
-    return True
+        return True
+    except Exception:
+        remove_dependency_logging(entry.entry_id)
+        raise
 
 
 async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -154,6 +162,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_listener()
 
         hass.data[DOMAIN].pop(entry.entry_id)
+
+        remove_dependency_logging(entry.entry_id)
 
     return True
 

--- a/custom_components/ims/dependency_logging.py
+++ b/custom_components/ims/dependency_logging.py
@@ -1,0 +1,76 @@
+"""Dependency logging helpers for the IMS integration."""
+
+from copy import copy
+import logging
+
+from loguru import logger as loguru_logger
+
+_WEATHERIL_LOGGER_PREFIX = "weatheril"
+_LOGURU_LOGGER_PREFIX = "loguru"
+_LOGURU_DEFAULT_SINK_ID = 0
+
+_loguru_sink_id: int | None = None
+_active_entry_ids: set[str] = set()
+
+
+class _DependencyLoggingHandler(logging.Handler):
+    """Forward weatheril Loguru records into Home Assistant logging."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if record.name.startswith(_LOGURU_LOGGER_PREFIX):
+            return
+        target_logger_name = f"{__package__}.{record.name}"
+        target_logger = logging.getLogger(target_logger_name)
+        if target_logger.isEnabledFor(record.levelno):
+            forward_record = copy(record)
+            forward_record.name = target_logger_name
+            target_logger.handle(forward_record)
+
+
+def setup_dependency_logging(entry_id: str) -> None:
+    """Idempotently route Loguru logs for weatheril to standard logging."""
+    global _loguru_sink_id
+
+    _active_entry_ids.add(entry_id)
+
+    try:
+        if _loguru_sink_id is not None:
+            return
+
+        try:
+            # Remove Loguru's process-wide default console sink so dependency logs
+            # do not bypass Home Assistant logging.
+            loguru_logger.remove(_LOGURU_DEFAULT_SINK_ID)
+        except ValueError:
+            pass
+
+        _loguru_sink_id = loguru_logger.add(
+            _DependencyLoggingHandler(),
+            filter=lambda record: record["name"].startswith(_WEATHERIL_LOGGER_PREFIX),
+            level=0,
+            format="{message}",
+        )
+    except Exception:
+        _active_entry_ids.discard(entry_id)
+        if not _active_entry_ids:
+            _remove_loguru_sink()
+        raise
+
+
+def remove_dependency_logging(entry_id: str) -> None:
+    """Release dependency logging for a config entry."""
+    _active_entry_ids.discard(entry_id)
+    if _active_entry_ids:
+        return
+    _remove_loguru_sink()
+
+
+def _remove_loguru_sink() -> None:
+    """Tear down the Loguru sink to avoid leaking memory on integration unload."""
+    global _loguru_sink_id
+    if _loguru_sink_id is not None:
+        try:
+            loguru_logger.remove(_loguru_sink_id)
+        except ValueError:
+            pass
+        _loguru_sink_id = None

--- a/custom_components/ims/dependency_logging.py
+++ b/custom_components/ims/dependency_logging.py
@@ -46,7 +46,7 @@ def setup_dependency_logging(entry_id: str) -> None:
 
         _loguru_sink_id = loguru_logger.add(
             _DependencyLoggingHandler(),
-            filter=lambda record: record["name"].startswith(_WEATHERIL_LOGGER_PREFIX),
+            filter=_WEATHERIL_LOGGER_PREFIX,
             level=0,
             format="{message}",
         )


### PR DESCRIPTION
Adds dependency logging support for the IMS integration by forwarding weatheril Loguru records into Home Assistant’s standard logging system.

Fixes #137

#### Changes

- Add `dependency_logging.py` to bridge `weatheril `Loguru output into HA logging.
- Track active config entry IDs so the shared Loguru sink is installed once and removed only after the last IMS entry unloads.
- Clean up dependency logging if config entry setup fails.
- Wire dependency logging setup/removal into `async_setup_entry `and `async_unload_entry`.