### PR TITLE
fix(binary_sensor): set correct entity_id domain for binary sensors

### DIFF
--- a/custom_components/ims/__init__.py
+++ b/custom_components/ims/__init__.py
@@ -6,6 +6,7 @@ from typing import Any
 from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
+from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_MODE,
@@ -225,7 +226,10 @@ class ImsEntity(CoordinatorEntity[WeatherUpdateCoordinator]):
             f"{description.key}_{coordinator.city}_{coordinator.language}"
         )
 
-        self.entity_id = "sensor." + description.key
+        if isinstance(self, BinarySensorEntity):
+            self.entity_id = f"binary_sensor.{description.key}"
+        else:
+            self.entity_id = f"sensor.{description.key}"
         self._attr_translation_key = f"{description.key}_{coordinator.language}"
         self.entity_description = description
 


### PR DESCRIPTION
The ImsEntity base class was hardcoding entity_id to sensor domain,
causing binary sensor entities to be registered with the wrong domain.
This led to Home Assistant warnings:
  Detected that custom integration 'ims' sets an entity ID with wrong domain:
  'sensor.ims_is_raining'. Expected domain is 'binary_sensor'.
  ...
Fix by checking if the instance is a BinarySensorEntity and setting
entity_id accordingly.

Fixes the warning for sensor.ims_is_raining and sensor.ims_is_active_weather_warning.