### PR TITLE
fix: handle None forecast from weatheril gracefully

### DIFF
--- a/custom_components/ims/sensor.py
+++ b/custom_components/ims/sensor.py
@@ -551,7 +551,7 @@ class ImsSensor(ImsEntity, SensorEntity):
                     if self.entity_description.key == sensor_keys.TYPE_FORECAST_TODAY
                     else int(self.entity_description.key[-1])
                 )
-                if day_index < len(data.forecast.days):
+                if data.forecast is not None and day_index < len(data.forecast.days):
                     daily_forecast = data.forecast.days[day_index]
                     self._attr_native_value = daily_forecast.day
                     self._attr_extra_state_attributes = (

--- a/custom_components/ims/weather_update_coordinator.py
+++ b/custom_components/ims/weather_update_coordinator.py
@@ -32,7 +32,7 @@ class WeatherData:
     """Weather data container."""
 
     current_weather: Weather
-    forecast: Forecast
+    forecast: Forecast | None
     images: RadarSatellite | None
     warnings: list[Warning]
 
@@ -90,7 +90,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[WeatherData]):
         current_weather = await loop.run_in_executor(
             None, self.weather.get_current_analysis
         )
-        weather_forecast = await loop.run_in_executor(None, self.weather.get_forecast)
+        weather_forecast = await self._fetch_forecast(loop)
         warnings = (
             await self._fetch_warnings(loop) if self._should_fetch_warnings() else []
         )
@@ -101,8 +101,31 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[WeatherData]):
             current_weather.forecast_time.strftime("%m/%d/%Y, %H:%M:%S"),
         )
 
-        self._filter_future_forecast(weather_forecast)
+        if weather_forecast is not None:
+            self._filter_future_forecast(weather_forecast)
+        else:
+            _LOGGER.warning(
+                "IMS returned no forecast data; continuing without forecast"
+            )
         return WeatherData(current_weather, weather_forecast, images, warnings)
+
+    async def _fetch_forecast(self, loop: asyncio.AbstractEventLoop) -> Forecast | None:
+        """Fetch weather forecast from IMS.
+
+        Non-fatal: returns ``None`` on any failure (timeout, network error,
+        parse error, server outage) so a misbehaving forecast endpoint cannot
+        prevent the rest of the update from completing.  The upstream
+        ``weatheril`` library may raise ``AttributeError`` when the IMS API
+        returns unexpected data (e.g. ``None`` hourly payload).
+        """
+        try:
+            return await loop.run_in_executor(None, self.weather.get_forecast)
+        except Exception as error:  # noqa: BLE001 - intentional, see docstring
+            _LOGGER.warning(
+                "Failed to fetch IMS weather forecast; continuing without it: %s",
+                error,
+            )
+            return None
 
     async def _fetch_warnings(self, loop: asyncio.AbstractEventLoop) -> list[Warning]:
         """Fetch active IMS weather warnings.


### PR DESCRIPTION
## Summary

The upstream `weatheril` library raises `AttributeError: 'NoneType' object has no attribute 'keys'` when the IMS API returns unexpected data in the hourly forecast endpoint. This crashes the entire coordinator update, causing the integration to enter a retry loop.

## Changes

- **`WeatherData.forecast`**: Changed type from `Forecast` to `Forecast | None`
- **`_fetch_forecast()`**: New method that wraps `get_forecast` in try/except (matching the existing `_fetch_warnings` / `_fetch_radar_images` pattern), returning `None` on any failure
- **`_get_ims_weather()`**: Skips `_filter_future_forecast` when forecast is `None` and logs a warning
- Downstream consumers (`weather.py`, `sensor.py`) already handle `None` forecast gracefully

## Testing

Verified that when `get_forecast` raises an exception, the coordinator continues with `current_weather`, `images`, and `warnings` intact — only the forecast is unavailable.

Closes #180